### PR TITLE
Fix: crash when zoom

### DIFF
--- a/android/src/main/java/com/keyee/pdfview/PDFViewManager.java
+++ b/android/src/main/java/com/keyee/pdfview/PDFViewManager.java
@@ -63,8 +63,7 @@ public class PDFViewManager extends SimpleViewManager<PdfView> {
 
     @ReactProp(name = "zoom")
     public void zoomTo(PdfView view, float zoomScale) {
-        PointF pivot = new PointF(zoomScale, zoomScale);
-        view.zoomCenteredTo(zoomScale, pivot);
+        view.zoomToScale(zoomScale);
     }
 
     private void showLog(final String str) {

--- a/android/src/main/java/com/keyee/pdfview/PdfView.java
+++ b/android/src/main/java/com/keyee/pdfview/PdfView.java
@@ -120,7 +120,7 @@ public class PdfView extends PDFView implements OnPageChangeListener, OnLoadComp
         display(false);
     }
 
-    public void zoomTo(float zoomScale) {
+    public void zoomToScale(float zoomScale) {
         PointF pivot = new PointF(zoomScale, zoomScale);
         this.zoomCenteredTo(zoomScale, pivot);
     }


### PR DESCRIPTION
# Summary

The `PdfView` inherits `com.github.barteksc.pdfviewer.PDFView` class, and it has `zoomTo` method, it accidentally overried `zoomTo` method of `com.github.barteksc.pdfviewer.PDFView` class.
When `PdfView` calls `zoomCenteredTo` of `com.github.barteksc.pdfviewer.PDFView` class, it will call `zoomTo` method again, then `zoomTo` method call `zoomCenteredTo`. So `StackOverflow` exception happens.

https://user-images.githubusercontent.com/40555128/109910927-bc135e00-7cdb-11eb-9a6d-f271f8e7eb2e.mp4

To fix the issue, just change the name of `zoomTo` method to `zoomToScale`


# Demo
https://user-images.githubusercontent.com/40555128/109910880-a736ca80-7cdb-11eb-964d-72cf813ed531.mp4

